### PR TITLE
fix lumen 5.5 errors

### DIFF
--- a/src/RoutesCommand.php
+++ b/src/RoutesCommand.php
@@ -26,11 +26,11 @@ class RoutesCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         global $app;
         
-        $routeCollection = $app->getRoutes();
+        $routeCollection = $app->router->getRoutes();
         $rows = array();
         foreach ($routeCollection as $route) {
             $rows[] = [


### PR DESCRIPTION
fixes this two errors on lumen 5.5

>  [ReflectionException]
>   Method Appzcoder\LumenRoutesList\RoutesCommand::handle() does not exist

>  [Symfony\Component\Debug\Exception\FatalThrowableError]
>   Call to undefined method Laravel\Lumen\Application::getRoutes()